### PR TITLE
fix regarding version matching

### DIFF
--- a/PatchManager.py
+++ b/PatchManager.py
@@ -162,6 +162,7 @@ class PatchManager(Processor):
         done = False
         for record in root.findall("versions/version"):
             if self.pkg.version in record.findtext("software_version"):
+                patch_def_software_version = record.findtext("software_version")
                 self.logger.debug("Found our version")
                 if record.findtext("package/name"):
                     self.logger.debug("Definition already points to package")
@@ -238,7 +239,7 @@ class PatchManager(Processor):
                         "Version %s already done" % self.pkg.version
                     )
                     return 0
-                root.find("general/target_version").text = self.pkg.version
+                root.find("general/target_version").text = patch_def_software_version
                 root.find("general/release_date").text = ""
                 root.find("general/enabled").text = "true"
                 # create a description with date

--- a/Production.py
+++ b/Production.py
@@ -178,7 +178,7 @@ class Production(Processor):
         # find the patch version that matches our version
         done = False
         for record in root.findall("versions/version"):
-            if record.findtext("software_version") == self.pkg.version:
+            if self.pkg.version in record.findtext("software_version"):
                 package = record.find("package")
                 add = ET.SubElement(package, "id")
                 add.text = self.pkg.idn


### PR DESCRIPTION
Ensuring we have the full version string from the matched patch def version list entry.
Example:
Zoom Client for Meetings has versions listed like so :: 5.3.1 (####.####)
We match the 5.3.1 and need to rest of the string to make the package data for the patch version list entry.
We capture the value after matching it, and use that value instead of the self.pkg.version, which is only a portion of the string.